### PR TITLE
✨ Compress HTML on error pages too

### DIFF
--- a/Classes/EelHelper/CompressionHelper.php
+++ b/Classes/EelHelper/CompressionHelper.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Carbon\Compression\EelHelper;
+
+use WyriHaximus\HtmlCompress\Factory as HtmlCompress;
+use Neos\Eel\ProtectedContextAwareInterface;
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * @Flow\Proxy(false)
+ */
+class CompressionHelper implements ProtectedContextAwareInterface
+{
+    /**
+     * Minify Html Content
+     *
+     * @param string $content
+     * @return string
+     */
+    public function compress(string $content): string
+    {
+        return HtmlCompress::construct()->compress($content);
+    }
+
+    /**
+     * All methods are considered safe
+     *
+     * @param string $methodName The name of the method
+     *
+     * @return bool
+     */
+    public function allowsCallOfMethod($methodName)
+    {
+        return true;
+    }
+}

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -5,6 +5,9 @@ Neos:
         minifyHtml:
           middleware: Carbon:Compression
           position: start
+  Fusion:
+    defaultContext:
+      Carbon.Compression: Carbon\Compression\EelHelper\CompressionHelper
   Neos:
     fusion:
       autoInclude:

--- a/Resources/Private/Fusion/Root.fusion
+++ b/Resources/Private/Fusion/Root.fusion
@@ -1,3 +1,7 @@
+error {
+    @process.compress = ${Carbon.Compression.compress(value)}
+}
+
 prototype(Neos.Neos:Page) {
     httpResponseHead {
         headers {


### PR DESCRIPTION
Usually, in case of an error, an Exception is thrown and the middleware is aborted. Thus on error pages no compression happens.

Using an EelHelper and
```
error {
    @process.compress = ${Carbon.Compression.compress(value)}
}
```
the error pages are compressed too.
